### PR TITLE
Use relative paths for images

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ console_scripts =
     smartem.init = smartem.cli.initialise:run
     smartem.start = smartem.cli.start:run
     smartem.stop = smartem.cli.stop:run
+    smartem.change_epu_dir = smartem.cli.change_epu_directory:run
 
 [options.packages.find]
 where = src

--- a/src/smartem/cli/change_epu_directory.py
+++ b/src/smartem/cli/change_epu_directory.py
@@ -1,0 +1,29 @@
+import argparse
+
+from smartem.data_model.extract import DataAPI
+
+
+def run():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-p",
+        "--project_name",
+        help="Name of project to change EPU directory of",
+        dest="project_name",
+    )
+    parser.add_argument(
+        "--new_epu_dir",
+        help="Path to new EPU directory",
+        dest="epu_dir",
+    )
+    parser.add_argument(
+        "--new_atlas_image",
+        help="Path to new Atlas image",
+        dest="atlas_image",
+    )
+    args = parser.parse_args()
+
+    extractor = DataAPI()
+    extractor.update_project(args.project_name, acquisition_directory=args.epu_dir)
+    project = extractor.get_project(project_name=args.project_name)
+    extractor.update_atlas(project.atlas_id, thumbnail=args.atlas_image)

--- a/src/smartem/data_model/extract.py
+++ b/src/smartem/data_model/extract.py
@@ -48,6 +48,24 @@ class DataAPI:
             )
         return query.all()[0]
 
+    def update_project(
+        self,
+        project_name: str,
+        acquisition_directory: str = "",
+        processing_directory: str = "",
+    ):
+        updated_values = {}
+        if acquisition_directory:
+            updated_values["acquisition_directory"] = acquisition_directory
+        if processing_directory:
+            updated_values["processing_directory"] = processing_directory
+        if not updated_values:
+            return
+        self.session.query(Project).filter(Project.project_name == project_name).update(
+            updated_values
+        )
+        self.session.commit()
+
     def get_projects(self) -> List[str]:
         query = self.session.query(Project).options(load_only("project_name"))
         return [q.project_name for q in query.all()]
@@ -73,6 +91,17 @@ class DataAPI:
                 return atlases[0]
             return atlases
         return []
+
+    def update_atlas(self, atlas_id: int, thumbnail: str = ""):
+        updated_values = {}
+        if thumbnail:
+            updated_values["thumbnail"] = thumbnail
+        if not updated_values:
+            return
+        self.session.query(Atlas).filter(Atlas.atlas_id == atlas_id).update(
+            updated_values
+        )
+        self.session.commit()
 
     def get_tile(
         self, stage_position: Tuple[float, float], atlas_id: Optional[int] = None

--- a/src/smartem/gui/qt/image_utils.py
+++ b/src/smartem/gui/qt/image_utils.py
@@ -1,5 +1,6 @@
 import math
 from itertools import cycle
+from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
 import matplotlib
@@ -84,6 +85,7 @@ class ImageLabel(QLabel):
         image: Union[Atlas, Tile, GridSquare, FoilHole, Exposure],
         contained_image: Optional[Union[GridSquare, FoilHole, Exposure]],
         image_size: Tuple[int, int],
+        image_directory: Path,
         overwrite_readout: bool = False,
         value: Optional[float] = None,
         extra_images: Optional[list] = None,
@@ -92,6 +94,7 @@ class ImageLabel(QLabel):
     ):
         super().__init__(**kwargs)
         self._image = image
+        self._image_directory = image_directory
         self._contained_image = contained_image
         self._extra_images = extra_images or []
         self._image_size = image_size
@@ -157,7 +160,9 @@ class ImageLabel(QLabel):
             pen.setWidth(3)
             painter.setPen(pen)
             if self._overwrite_readout:
-                with mrcfile.open(self._image.thumbnail.replace(".jpg", ".mrc")) as mrc:
+                with mrcfile.open(
+                    (self._image_directory / self._image.thumbnail).with_suffix(".mrc")
+                ) as mrc:
                     readout_area = mrc.data.shape
             else:
                 readout_area = (self._image.readout_area_x, self._image.readout_area_y)

--- a/src/smartem/parsing/epu.py
+++ b/src/smartem/parsing/epu.py
@@ -74,7 +74,7 @@ def parse_epu_dir(epu_path: Path, extractor: DataAPI):
                             grid_square_name=grid_square_dir.name,
                             stage_position_x=grid_square_data["stage_position"][0],
                             stage_position_y=grid_square_data["stage_position"][1],
-                            thumbnail=str(grid_square_jpeg),
+                            thumbnail=str(grid_square_jpeg.relative_to(epu_path)),
                             pixel_size=grid_square_data["pixel_size"],
                             readout_area_x=grid_square_data["readout_area"][0],
                             readout_area_y=grid_square_data["readout_area"][1],
@@ -86,16 +86,15 @@ def parse_epu_dir(epu_path: Path, extractor: DataAPI):
                 foil_hole_name = "_".join(foil_hole_jpeg.stem.split("_")[:2])
                 if foil_holes.get(foil_hole_name):
                     if (
-                        Path(foil_holes[foil_hole_name].thumbnail).stat().st_mtime
-                        > foil_hole_jpeg.stat().st_mtime
-                    ):
+                        epu_path / foil_holes[foil_hole_name].thumbnail
+                    ).stat().st_mtime > foil_hole_jpeg.stat().st_mtime:
                         continue
                 foil_hole_data = parse_epu_xml(foil_hole_jpeg.with_suffix(".xml"))
                 foil_holes[foil_hole_name] = FoilHole(
                     grid_square_name=grid_square_dir.name,
                     stage_position_x=foil_hole_data["stage_position"][0],
                     stage_position_y=foil_hole_data["stage_position"][1],
-                    thumbnail=str(foil_hole_jpeg),
+                    thumbnail=str(foil_hole_jpeg.relative_to(epu_path)),
                     pixel_size=foil_hole_data["pixel_size"],
                     readout_area_x=foil_hole_data["readout_area"][0],
                     readout_area_y=foil_hole_data["readout_area"][0],
@@ -115,7 +114,7 @@ def parse_epu_dir(epu_path: Path, extractor: DataAPI):
                     foil_hole_name=foil_hole_name,
                     stage_position_x=exposure_data["stage_position"][0],
                     stage_position_y=exposure_data["stage_position"][1],
-                    thumbnail=str(exposure_jpeg),
+                    thumbnail=str(exposure_jpeg.relative_to(epu_path)),
                     pixel_size=exposure_data["pixel_size"],
                     readout_area_x=exposure_data["readout_area"][0],
                     readout_area_y=exposure_data["readout_area"][1],


### PR DESCRIPTION
This will increase the portability of projects as only two paths per project have to be changed in the database if the images are moved, e.g. they're downloaded to a new location