### PR TITLE
Add pytorch custom DataLoader

### DIFF
--- a/src/smartem/data_model/extract.py
+++ b/src/smartem/data_model/extract.py
@@ -452,7 +452,6 @@ class DataAPI:
         exposure_keys: List[str],
         particle_keys: List[str],
         particle_set_keys: List[str],
-        avg_particles: bool = False,
     ) -> List[tuple]:
         info: List[tuple] = []
         if not any((exposure_keys, particle_keys, particle_set_keys)):
@@ -495,7 +494,6 @@ class DataAPI:
         exposure_keys: List[str],
         particle_keys: List[str],
         particle_set_keys: List[str],
-        avg_particles: bool = False,
     ) -> List[tuple]:
         info: List[tuple] = []
         if not any((exposure_keys, particle_keys, particle_set_keys)):
@@ -544,7 +542,6 @@ class DataAPI:
         exposure_keys: List[str],
         particle_keys: List[str],
         particle_set_keys: List[str],
-        avg_particles: bool = False,
     ) -> List[tuple]:
         info: List[tuple] = []
         if not any((exposure_keys, particle_keys, particle_set_keys)):

--- a/src/smartem/data_model/torch.py
+++ b/src/smartem/data_model/torch.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+from typing import List, Sequence, Tuple
+
+from torch import Tensor
+from torch.utils.data import DataLoader
+from torchvision.io import read_image
+
+from smartem.data_model import EPUImage, FoilHole, GridSquare
+from smartem.data_model.extract import DataAPI
+from smartem.data_model.structure import (
+    extract_keys_with_foil_hole_averages,
+    extract_keys_with_grid_square_averages,
+)
+
+
+class SmartEMDataLoader(DataLoader):
+    def __init__(
+        self,
+        level: str,
+        epu_dir: Path,
+        atlas_id: int,
+        data_api: DataAPI,
+        mrc: bool = False,
+    ):
+        self._data_api = data_api
+        self._level = level
+        self._epu_dir = epu_dir
+        self._mrc = mrc
+        atlas_info = self._data_api.get_atlas_info(
+            atlas_id,
+            ["_rlnaccummotiontotal", "_rlnctfmaxresolution"],
+            [],
+            ["_rlnestimatedresolution"],
+        )
+        if self._level not in ("grid_square", "foil_hole"):
+            raise ValueError(
+                f"Unrecognised SmartEMDataLoader level {self._level}: accepted values are grid_sqaure or foil_hole"
+            )
+        exposures = self._data_api.get_exposures()
+        particles = self._data_api.get_particles()
+        self._indexed: Sequence[EPUImage] = []
+        if self._level == "grid_square":
+            _, self._labels = extract_keys_with_grid_square_averages(
+                atlas_info,
+                ["_rlnaccummotiontotal", "_rlnctfmaxresolution"],
+                [],
+                ["_rlnestimatedresolution"],
+                exposures,
+                particles,
+            )
+            _gs_indexed: Sequence[GridSquare] = self._data_api.get_grid_squares()
+            self._image_paths = {p.grid_square_name: p.thumbnail for p in _gs_indexed}
+            self._indexed = _gs_indexed
+        elif self._level == "foil_hole":
+            _, self._labels = extract_keys_with_foil_hole_averages(
+                atlas_info,
+                ["_rlnaccummotiontotal", "_rlnctfmaxresolution"],
+                [],
+                ["_rlnestimatedresolution"],
+                exposures,
+                particles,
+            )
+            _fh_indexed: Sequence[FoilHole] = self._data_api.get_foil_holes()
+            self._image_paths = {p.foil_hole_name: p.thumbnail for p in _fh_indexed}
+            self._indexed = _fh_indexed
+
+    def __len__(self) -> int:
+        return len(self._image_paths)
+
+    def __getitem__(self, idx: int) -> Tuple[Tensor, List[float]]:
+        # ordered_labels = [
+        #     "_rlnaccummotiontotal",
+        #     "_rlnctfmaxresolution",
+        #     "_rlnestimatedresolution",
+        # ]
+        if self._level == "grid_square":
+            index_name = self._indexed[idx].grid_square_name  # type: ignore
+        elif self._label == "foil_hole":
+            index_name = self._indexed[idx].foil_hole_name  # type: ignore
+        image = read_image(str(self._epu_dir / self._image_paths[index_name]))
+        labels = [
+            self._labels[index_name]
+        ]  # this needs changing so that we can get averages over all keys at once
+        return image, labels

--- a/src/smartem/data_model/torch.py
+++ b/src/smartem/data_model/torch.py
@@ -68,17 +68,15 @@ class SmartEMDataLoader(DataLoader):
         return len(self._image_paths)
 
     def __getitem__(self, idx: int) -> Tuple[Tensor, List[float]]:
-        # ordered_labels = [
-        #     "_rlnaccummotiontotal",
-        #     "_rlnctfmaxresolution",
-        #     "_rlnestimatedresolution",
-        # ]
+        ordered_labels = [
+            "_rlnaccummotiontotal",
+            "_rlnctfmaxresolution",
+            "_rlnestimatedresolution",
+        ]
         if self._level == "grid_square":
             index_name = self._indexed[idx].grid_square_name  # type: ignore
         elif self._label == "foil_hole":
             index_name = self._indexed[idx].foil_hole_name  # type: ignore
         image = read_image(str(self._epu_dir / self._image_paths[index_name]))
-        labels = [
-            self._labels[index_name]
-        ]  # this needs changing so that we can get averages over all keys at once
+        labels = [self._labels[l][index_name] for l in ordered_labels]
         return image, labels

--- a/src/smartem/gui/qt/__init__.py
+++ b/src/smartem/gui/qt/__init__.py
@@ -272,7 +272,7 @@ class MainDisplay(ComponentTab):
         self._extractor = extractor
         self._epu_dir: Optional[Path] = None
         self._data: Dict[str, List[float]] = {}
-        self._foil_hole_averages: Dict[str, float] = {}
+        self._foil_hole_averages: Dict[str, Dict[str, float]] = {}
         self._particle_data: Dict[str, List[float]] = {}
         self._exposure_keys: List[str] = []
         self._particle_keys: List[str] = []
@@ -635,7 +635,7 @@ class MainDisplay(ComponentTab):
             if len(self._data.keys()) == 1:
                 _key = list(self._data.keys())[0]
                 imvs = [
-                    self._foil_hole_averages.get(fh.foil_hole_name)
+                    list(self._foil_hole_averages.values())[0].get(fh.foil_hole_name)
                     for fh in self._foil_holes
                     if fh != foil_hole
                 ]
@@ -645,7 +645,9 @@ class MainDisplay(ComponentTab):
                 (qsize.width(), qsize.height()),
                 self._epu_dir,
                 parent=self,
-                value=self._foil_hole_averages.get(foil_hole.foil_hole_name)
+                value=list(self._foil_hole_averages.values())[0].get(
+                    foil_hole.foil_hole_name
+                )
                 if _key
                 else None,
                 extra_images=[fh for fh in self._foil_holes if fh != foil_hole],
@@ -798,7 +800,7 @@ class AtlasDisplay(QWidget):
         self._atlas_stats_fig.set_facecolor("silver")
         self._atlas_stats = FigureCanvasQTAgg(atlas_fig)
         self._data: Dict[str, List[float]] = {}
-        self._grid_square_averages: Dict[str, float] = {}
+        self._grid_square_averages: Dict[str, Dict[str, float]] = {}
         self._particle_data: Dict[str, List[float]] = {}
         self._colour_bar = None
         self._grid_square: Optional[GridSquare] = None
@@ -890,7 +892,9 @@ class AtlasDisplay(QWidget):
                     and len(self._data.keys()) == 1
                 ):
                     imvs = [
-                        self._grid_square_averages.get(gs.grid_square_name)
+                        list(self._grid_square_averages.values())[0].get(
+                            gs.grid_square_name
+                        )
                         for gs in all_grid_squares
                         if gs != grid_square
                     ]
@@ -903,7 +907,9 @@ class AtlasDisplay(QWidget):
                     epu_dir,
                     parent=self,
                     overwrite_readout=True,
-                    value=self._grid_square_averages.get(grid_square.grid_square_name)
+                    value=list(self._grid_square_averages.values())[0].get(
+                        grid_square.grid_square_name
+                    )
                     if imvs
                     else None,
                     extra_images=[gs for gs in all_grid_squares if gs != grid_square]


### PR DESCRIPTION
The custom DataLoader loads labels and image paths from the `smartem` database. Currently it only deals with the EPU jpeg images. To cover MRC as well it will need to be able to parse MRC data into a pytorch `Tensor`