### PR TITLE
UI convenience change

### DIFF
--- a/src/smartem/gui/qt/__init__.py
+++ b/src/smartem/gui/qt/__init__.py
@@ -657,6 +657,7 @@ class MainDisplay(ComponentTab):
                     fh for fh in self._foil_holes if fh != foil_hole and fh.thumbnail
                 ],
                 image_values=imvs,
+                selection_box=self._square_combo,
             )
             self.grid.addWidget(square_lbl, 1, 1)
             square_lbl.setPixmap(square_pixmap)
@@ -686,6 +687,7 @@ class MainDisplay(ComponentTab):
                     (qsize.width(), qsize.height()),
                     self._epu_dir,
                     parent=self,
+                    selection_box=self._foil_hole_combo,
                 )
                 self.grid.addWidget(hole_lbl, 1, 2)
                 hole_lbl.setPixmap(hole_pixmap)
@@ -772,6 +774,7 @@ class MainDisplay(ComponentTab):
             image_scale=0.5
             if self._data_size is None
             else thumbnail_size[0] / self._data_size[0],
+            selection_box=self._exposure_combo,
         )
         self.grid.addWidget(exposure_lbl, 1, 3)
         exposure_lbl.setPixmap(exposure_pixmap)

--- a/src/smartem/gui/qt/image_utils.py
+++ b/src/smartem/gui/qt/image_utils.py
@@ -8,7 +8,7 @@ import mrcfile
 import numpy as np
 from PyQt5 import QtCore
 from PyQt5.QtGui import QBrush, QColor, QPainter, QPen
-from PyQt5.QtWidgets import QLabel
+from PyQt5.QtWidgets import QComboBox, QLabel
 
 from smartem.data_model import Atlas, Exposure, FoilHole, GridSquare, Particle, Tile
 from smartem.stage_model import find_point_pixel
@@ -29,6 +29,7 @@ class ParticleImageLabel(QLabel):
         particles: Union[List[Particle], List[List[Particle]]],
         image_size: Tuple[int, int],
         image_scale: float = 0.5,
+        selection_box: Optional[QComboBox] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -36,6 +37,12 @@ class ParticleImageLabel(QLabel):
         self._image_size = image_size
         self._particles = particles
         self._image_scale = image_scale
+        self._selection_box = selection_box
+
+    def mousePressEvent(self, ev):
+        if self._selection_box is not None:
+            self._selection_box.setFocus()
+            self._selection_box.activateWindow()
 
     def draw_circle(
         self, coordinates: Tuple[float, float], diameter: int, painter: QPainter
@@ -97,6 +104,7 @@ class ImageLabel(QLabel):
         value: Optional[float] = None,
         extra_images: Optional[list] = None,
         image_values: Optional[List[float]] = None,
+        selection_box: Optional[QComboBox] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -108,6 +116,12 @@ class ImageLabel(QLabel):
         self._overwrite_readout = overwrite_readout
         self._value = value
         self._image_values = image_values or []
+        self._selection_box = selection_box
+
+    def mousePressEvent(self, ev):
+        if self._selection_box is not None:
+            self._selection_box.setFocus()
+            self._selection_box.activateWindow()
 
     def draw_rectangle(
         self,


### PR DESCRIPTION
Clicking on a grid square, foil hole or exposure image shifts keyboard focus to the corresponding combo box